### PR TITLE
Auto-trigger ActBlue landing page screenshots on ingestion

### DIFF
--- a/web/src/app/api/inbound-sms/route.ts
+++ b/web/src/app/api/inbound-sms/route.ts
@@ -63,6 +63,26 @@ export async function POST(req: NextRequest) {
     if (result.isFundraising && result.id) {
       triggerPipelines(result.id);
       console.log("/api/inbound-sms:triggered_pipelines", { submissionId: result.id });
+      
+      // If ActBlue landing URL detected, trigger screenshot capture
+      if (result.landingUrl) {
+        const base = process.env.NEXT_PUBLIC_SITE_URL || "";
+        void fetch(`${base}/api/screenshot-actblue`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ caseId: result.id, url: result.landingUrl }),
+        }).then(async (r) => {
+          const text = await r.text().catch(() => "");
+          console.log("/api/inbound-sms:screenshot_triggered", { 
+            status: r.status, 
+            caseId: result.id,
+            url: result.landingUrl,
+            response: text?.slice(0, 200) 
+          });
+        }).catch((e) => {
+          console.error("/api/inbound-sms:screenshot_error", String(e));
+        });
+      }
     } else {
       console.log("/api/inbound-sms:skipped_triggers_non_fundraising", { submissionId: result.id });
     }

--- a/web/src/server/ingest/save.ts
+++ b/web/src/server/ingest/save.ts
@@ -18,6 +18,7 @@ export type IngestResult = {
   error?: string;
   isFundraising?: boolean;
   heuristic?: { score: number; hits: string[] };
+  landingUrl?: string | null;
 };
 
 function computeHeuristic(text: string): { isFundraising: boolean; score: number; hits: string[] } {
@@ -150,8 +151,8 @@ export async function ingestTextSubmission(params: IngestTextParams): Promise<In
     return { ok: false, error: error.message };
   }
   const id = (data as any)?.id as string | undefined;
-  console.log("ingestTextSubmission:inserted", { id: id || null, isFundraising, score: heur.score, hits: heur.hits });
-  return { ok: true, id, isFundraising, heuristic: heur };
+  console.log("ingestTextSubmission:inserted", { id: id || null, isFundraising, score: heur.score, hits: heur.hits, landingUrl: landingUrl || null });
+  return { ok: true, id, isFundraising, heuristic: heur, landingUrl: landingUrl || null };
 }
 
 export function triggerPipelines(submissionId: string) {


### PR DESCRIPTION
- Automatically capture screenshots when ActBlue URLs are detected in emails/SMS
- Return landingUrl in IngestResult for downstream processing
- Trigger screenshot API immediately after successful ingestion
- Works for both inbound-email and inbound-sms pipelines

No more manual screenshot triggering needed - landing pages are automatically captured and included in AI classification.