### PR TITLE
feat: email case preview to submitters after classification

### DIFF
--- a/web/sql/2025-10-08_add_forwarder_email.sql
+++ b/web/sql/2025-10-08_add_forwarder_email.sql
@@ -1,0 +1,19 @@
+-- Add forwarder email and submission token for email-based case preview feature
+-- Allows users who forward emails to receive a preview and submit directly from inbox
+
+alter table submissions add column if not exists forwarder_email text;
+alter table submissions add column if not exists submission_token text;
+alter table submissions add column if not exists token_used_at timestamptz;
+alter table submissions add column if not exists preview_email_sent_at timestamptz;
+alter table submissions add column if not exists preview_email_status text;
+
+-- Index for fast token lookups
+create index if not exists submissions_token_idx on submissions(submission_token);
+
+-- Comments for documentation
+comment on column submissions.forwarder_email is 'Email address of the person who forwarded the message to submit@abjail.org';
+comment on column submissions.submission_token is 'Secure one-time token for submitting report via email link';
+comment on column submissions.token_used_at is 'Timestamp when the submission token was used (null = unused)';
+comment on column submissions.preview_email_sent_at is 'Timestamp when preview email was sent to forwarder';
+comment on column submissions.preview_email_status is 'Status of preview email: pending, sent, failed';
+

--- a/web/src/app/api/send-case-preview/route.ts
+++ b/web/src/app/api/send-case-preview/route.ts
@@ -1,0 +1,239 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Resend } from "resend";
+import { env } from "@/lib/env";
+import { getSupabaseServer } from "@/lib/supabase-server";
+
+function parseSupabaseUrl(u: string | null | undefined) {
+  if (!u || !u.startsWith("supabase://")) return null;
+  const rest = u.replace("supabase://", "");
+  const [bucket, ...pathParts] = rest.split("/");
+  const path = pathParts.join("/");
+  return { bucket, path };
+}
+
+export async function POST(req: NextRequest) {
+  console.log("/api/send-case-preview:start");
+  
+  if (!env.RESEND_API_KEY) {
+    console.error("/api/send-case-preview:error resend_key_missing");
+    return NextResponse.json({ error: "resend_key_missing" }, { status: 400 });
+  }
+
+  const resend = new Resend(env.RESEND_API_KEY);
+  const supabase = getSupabaseServer();
+
+  const body = await req.json().catch(() => null);
+  const submissionId: string | undefined = body?.submissionId;
+  
+  if (!submissionId) {
+    console.error("/api/send-case-preview:error missing_args", { body });
+    return NextResponse.json({ error: "missing_args" }, { status: 400 });
+  }
+
+  // Fetch submission data
+  const { data: rows, error: err } = await supabase
+    .from("submissions")
+    .select("id, sender_name, sender_id, forwarder_email, submission_token, preview_email_sent_at, image_url, landing_url")
+    .eq("id", submissionId)
+    .limit(1);
+
+  if (err) {
+    console.error("/api/send-case-preview:error load_failed", err);
+    return NextResponse.json({ error: "load_failed" }, { status: 500 });
+  }
+
+  const sub = rows?.[0] as
+    | { id: string; sender_name?: string | null; sender_id?: string | null; forwarder_email?: string | null; submission_token?: string | null; preview_email_sent_at?: string | null; image_url?: string | null; landing_url?: string | null }
+    | undefined;
+
+  if (!sub) {
+    console.error("/api/send-case-preview:error not_found");
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  // Skip if no forwarder email (screenshot/paste submissions)
+  if (!sub.forwarder_email) {
+    console.log("/api/send-case-preview:skip no_forwarder_email", { submissionId });
+    return NextResponse.json({ ok: true, skipped: "no_forwarder_email" }, { status: 200 });
+  }
+
+  // Skip if already sent (prevent duplicates on re-classification)
+  if (sub.preview_email_sent_at) {
+    console.log("/api/send-case-preview:skip already_sent", { submissionId, sentAt: sub.preview_email_sent_at });
+    return NextResponse.json({ ok: true, skipped: "already_sent" }, { status: 200 });
+  }
+
+  // Load violations
+  const { data: vioRows } = await supabase
+    .from("violations")
+    .select("code, title, description")
+    .eq("submission_id", sub.id)
+    .order("severity", { ascending: false });
+
+  const violations = Array.isArray(vioRows) ? vioRows : [];
+
+  // Get campaign name
+  const campaign = sub.sender_name || sub.sender_id || "(unknown sender)";
+
+  // Get screenshot URL (create signed URL if needed)
+  let screenshotUrl: string | null = sub.image_url || null;
+  if (screenshotUrl && !screenshotUrl.startsWith("http")) {
+    const parsed = parseSupabaseUrl(screenshotUrl);
+    if (parsed) {
+      try {
+        const { data: signed } = await supabase.storage.from(parsed.bucket).createSignedUrl(parsed.path, 86400); // 24h expiry
+        screenshotUrl = signed?.signedUrl || screenshotUrl;
+      } catch {
+        screenshotUrl = null;
+      }
+    }
+  }
+
+  // Build email content
+  const shortId = sub.id.split("-")[0];
+  const caseUrl = `${env.NEXT_PUBLIC_SITE_URL}/cases/${sub.id}`;
+  const submitUrl = `${env.NEXT_PUBLIC_SITE_URL}/api/submit-report-via-email?token=${encodeURIComponent(sub.submission_token || "")}`;
+
+  // Format violations as HTML
+  const esc = (s: string) => String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+  const vioHtml = violations.length > 0
+    ? `<ul style="margin:0;padding-left:20px">${violations.map((v) => `<li style="margin:4px 0"><strong>${esc(v.code)}</strong> ${esc(v.title)}${v.description ? `: ${esc(v.description)}` : ""}</li>`).join("")}</ul>`
+    : `<p style="margin:0;color:#64748b">(No violations detected)</p>`;
+
+  const landingUrl = sub.landing_url || null;
+
+  // Email HTML with inline styles for email clients
+  const html = `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif;line-height:1.5;color:#0f172a;margin:0;padding:0;background-color:#f8fafc">
+  <div style="max-width:600px;margin:0 auto;padding:20px">
+    <!-- Header -->
+    <div style="background:linear-gradient(135deg,#3b82f6,#1e40af);color:white;padding:24px;border-radius:12px 12px 0 0;text-align:center">
+      <h1 style="margin:0;font-size:24px;font-weight:700">Your AB Jail Case is Ready</h1>
+      <p style="margin:8px 0 0 0;opacity:0.9;font-size:14px">Case #${esc(shortId)}</p>
+    </div>
+    
+    <!-- Content -->
+    <div style="background:white;padding:24px;border-radius:0 0 12px 12px;box-shadow:0 1px 3px rgba(0,0,0,0.1)">
+      <p style="margin:0 0 20px 0;color:#475569;font-size:15px">
+        Your submitted case has been analyzed. Review the details below and submit your report to ActBlue.
+      </p>
+
+      <!-- Campaign/Org -->
+      <div style="margin-bottom:20px">
+        <h2 style="margin:0 0 8px 0;font-size:14px;font-weight:600;color:#64748b;text-transform:uppercase;letter-spacing:0.5px">Campaign/Organization</h2>
+        <p style="margin:0;font-size:16px;font-weight:500;color:#0f172a">${esc(campaign)}</p>
+      </div>
+
+      <!-- Violations -->
+      <div style="margin-bottom:20px">
+        <h2 style="margin:0 0 8px 0;font-size:14px;font-weight:600;color:#64748b;text-transform:uppercase;letter-spacing:0.5px">Detected Violations</h2>
+        ${vioHtml}
+      </div>
+
+      <!-- Landing Page -->
+      ${landingUrl ? `
+      <div style="margin-bottom:20px">
+        <h2 style="margin:0 0 8px 0;font-size:14px;font-weight:600;color:#64748b;text-transform:uppercase;letter-spacing:0.5px">Landing Page</h2>
+        <p style="margin:0;font-size:14px"><a href="${esc(landingUrl)}" style="color:#3b82f6;text-decoration:underline">${esc(landingUrl)}</a></p>
+      </div>
+      ` : ""}
+
+      <!-- Screenshot -->
+      ${screenshotUrl ? `
+      <div style="margin-bottom:24px">
+        <h2 style="margin:0 0 8px 0;font-size:14px;font-weight:600;color:#64748b;text-transform:uppercase;letter-spacing:0.5px">Screenshot</h2>
+        <p style="margin:0;font-size:14px"><a href="${esc(screenshotUrl)}" style="color:#3b82f6;text-decoration:underline">View Screenshot</a></p>
+      </div>
+      ` : ""}
+
+      <!-- Action Buttons -->
+      <div style="margin-top:32px;text-align:center">
+        <a href="${submitUrl}" style="display:inline-block;background:#3b82f6;color:white;text-decoration:none;padding:14px 32px;border-radius:8px;font-weight:600;font-size:16px;margin:8px">
+          Submit to ActBlue
+        </a>
+        <a href="${caseUrl}" style="display:inline-block;background:white;color:#3b82f6;text-decoration:none;padding:14px 32px;border-radius:8px;font-weight:600;font-size:16px;border:2px solid #3b82f6;margin:8px">
+          Open on AB Jail
+        </a>
+      </div>
+
+      <!-- Footer Note -->
+      <div style="margin-top:32px;padding-top:20px;border-top:1px solid #e2e8f0;text-align:center">
+        <p style="margin:0;font-size:13px;color:#64748b">
+          This case was created from your submission to submit@abjail.org
+        </p>
+        <p style="margin:8px 0 0 0;font-size:12px;color:#94a3b8">
+          Case UUID: ${esc(sub.id)}
+        </p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>`;
+
+  // Plain text version
+  const text = `Your AB Jail Case is Ready - Case #${shortId}
+
+Campaign/Organization
+${campaign}
+
+Detected Violations
+${violations.length > 0 ? violations.map((v) => `- ${v.code} ${v.title}${v.description ? `: ${v.description}` : ""}`).join("\n") : "(No violations detected)"}
+
+${landingUrl ? `Landing Page\n${landingUrl}\n` : ""}
+${screenshotUrl ? `Screenshot\n${screenshotUrl}\n` : ""}
+
+Submit to ActBlue: ${submitUrl}
+Open on AB Jail: ${caseUrl}
+
+---
+This case was created from your submission to submit@abjail.org
+Case UUID: ${sub.id}`;
+
+  // Send email
+  try {
+    await resend.emails.send({
+      from: "AB Jail <notifications@abjail.org>",
+      to: sub.forwarder_email,
+      subject: `Your AB Jail case is ready - Case #${shortId}`,
+      text,
+      html,
+    });
+
+    // Mark as sent
+    await supabase
+      .from("submissions")
+      .update({
+        preview_email_sent_at: new Date().toISOString(),
+        preview_email_status: "sent",
+      })
+      .eq("id", submissionId);
+
+    console.log("/api/send-case-preview:success", { submissionId, to: sub.forwarder_email });
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (e) {
+    console.error("/api/send-case-preview:send_failed", e);
+    
+    // Mark as failed
+    await supabase
+      .from("submissions")
+      .update({
+        preview_email_sent_at: new Date().toISOString(),
+        preview_email_status: "failed",
+      })
+      .eq("id", submissionId);
+
+    return NextResponse.json({ error: "send_failed" }, { status: 500 });
+  }
+}
+

--- a/web/src/app/api/submit-report-via-email/route.ts
+++ b/web/src/app/api/submit-report-via-email/route.ts
@@ -1,0 +1,393 @@
+import { NextRequest, NextResponse } from "next/server";
+import { env } from "@/lib/env";
+import { getSupabaseServer } from "@/lib/supabase-server";
+
+export async function GET(req: NextRequest) {
+  console.log("/api/submit-report-via-email:start");
+  
+  const { searchParams } = new URL(req.url);
+  const token = searchParams.get("token");
+
+  if (!token) {
+    return new NextResponse(
+      renderErrorPage("Invalid Link", "This link is missing required parameters."),
+      {
+        status: 400,
+        headers: { "Content-Type": "text/html" },
+      }
+    );
+  }
+
+  const supabase = getSupabaseServer();
+
+  // Find submission by token
+  const { data: rows, error: err } = await supabase
+    .from("submissions")
+    .select("id, landing_url, token_used_at")
+    .eq("submission_token", token)
+    .limit(1);
+
+  if (err || !rows?.[0]) {
+    console.error("/api/submit-report-via-email:error not_found", { token: token.slice(0, 10) });
+    return new NextResponse(
+      renderErrorPage("Case Not Found", "This submission link is invalid or has expired."),
+      {
+        status: 404,
+        headers: { "Content-Type": "text/html" },
+      }
+    );
+  }
+
+  const sub = rows[0] as { id: string; landing_url?: string | null; token_used_at?: string | null };
+
+  // Check if token already used
+  if (sub.token_used_at) {
+    console.log("/api/submit-report-via-email:already_used", { id: sub.id, usedAt: sub.token_used_at });
+    const caseUrl = `${env.NEXT_PUBLIC_SITE_URL}/cases/${sub.id}`;
+    return new NextResponse(
+      renderInfoPage(
+        "Already Submitted",
+        "This report has already been submitted to ActBlue.",
+        caseUrl
+      ),
+      {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      }
+    );
+  }
+
+  // Check if landing URL exists
+  if (!sub.landing_url) {
+    console.error("/api/submit-report-via-email:error missing_landing_url", { id: sub.id });
+    const caseUrl = `${env.NEXT_PUBLIC_SITE_URL}/cases/${sub.id}`;
+    return new NextResponse(
+      renderErrorPage(
+        "Missing Landing Page",
+        "This case does not have a landing page URL. Please visit the case page to add one before submitting.",
+        caseUrl
+      ),
+      {
+        status: 400,
+        headers: { "Content-Type": "text/html" },
+      }
+    );
+  }
+
+  // Mark token as used immediately to prevent double-submissions
+  await supabase
+    .from("submissions")
+    .update({ token_used_at: new Date().toISOString() })
+    .eq("id", sub.id);
+
+  // Call the report-violation endpoint internally
+  try {
+    const base = env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+    const reportRes = await fetch(`${base}/api/report-violation`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        caseId: sub.id,
+        landingUrl: sub.landing_url,
+      }),
+    });
+
+    if (!reportRes.ok) {
+      const errData = await reportRes.json().catch(() => ({}));
+      console.error("/api/submit-report-via-email:report_failed", { id: sub.id, status: reportRes.status, error: errData });
+      
+      const caseUrl = `${env.NEXT_PUBLIC_SITE_URL}/cases/${sub.id}`;
+      return new NextResponse(
+        renderErrorPage(
+          "Submission Failed",
+          "Failed to submit report to ActBlue. Please try again from the case page.",
+          caseUrl
+        ),
+        {
+          status: 500,
+          headers: { "Content-Type": "text/html" },
+        }
+      );
+    }
+
+    console.log("/api/submit-report-via-email:success", { id: sub.id });
+    const caseUrl = `${env.NEXT_PUBLIC_SITE_URL}/cases/${sub.id}`;
+    return new NextResponse(
+      renderSuccessPage(sub.id, caseUrl),
+      {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      }
+    );
+  } catch (e) {
+    console.error("/api/submit-report-via-email:exception", e);
+    const caseUrl = `${env.NEXT_PUBLIC_SITE_URL}/cases/${sub.id}`;
+    return new NextResponse(
+      renderErrorPage(
+        "Submission Error",
+        "An unexpected error occurred. Please try again from the case page.",
+        caseUrl
+      ),
+      {
+        status: 500,
+        headers: { "Content-Type": "text/html" },
+      }
+    );
+  }
+}
+
+function renderSuccessPage(caseId: string, caseUrl: string): string {
+  const shortId = caseId.split("-")[0];
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Report Submitted - AB Jail</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+      line-height: 1.6;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+    }
+    .container {
+      background: white;
+      border-radius: 16px;
+      box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+      max-width: 500px;
+      width: 100%;
+      padding: 40px;
+      text-align: center;
+    }
+    .icon {
+      width: 80px;
+      height: 80px;
+      background: linear-gradient(135deg, #3b82f6, #1e40af);
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 24px;
+    }
+    .checkmark {
+      width: 40px;
+      height: 40px;
+      border: 4px solid white;
+      border-radius: 50%;
+      border-left-color: transparent;
+      border-top-color: transparent;
+      transform: rotate(45deg);
+    }
+    h1 {
+      font-size: 28px;
+      color: #0f172a;
+      margin-bottom: 12px;
+      font-weight: 700;
+    }
+    p {
+      color: #475569;
+      margin-bottom: 24px;
+      font-size: 16px;
+    }
+    .case-id {
+      background: #f1f5f9;
+      padding: 12px;
+      border-radius: 8px;
+      font-family: monospace;
+      font-size: 14px;
+      color: #334155;
+      margin-bottom: 32px;
+    }
+    a {
+      display: inline-block;
+      background: linear-gradient(135deg, #3b82f6, #1e40af);
+      color: white;
+      text-decoration: none;
+      padding: 14px 32px;
+      border-radius: 8px;
+      font-weight: 600;
+      font-size: 16px;
+      transition: transform 0.2s, box-shadow 0.2s;
+    }
+    a:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 8px 20px rgba(59,130,246,0.4);
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="icon">
+      <div class="checkmark"></div>
+    </div>
+    <h1>Report Submitted!</h1>
+    <p>Your report has been successfully submitted to ActBlue. They will review the case and take appropriate action.</p>
+    <div class="case-id">Case #${shortId}</div>
+    <a href="${caseUrl}">View Case Details</a>
+  </div>
+</body>
+</html>`;
+}
+
+function renderErrorPage(title: string, message: string, caseUrl?: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${title} - AB Jail</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+      line-height: 1.6;
+      background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+    }
+    .container {
+      background: white;
+      border-radius: 16px;
+      box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+      max-width: 500px;
+      width: 100%;
+      padding: 40px;
+      text-align: center;
+    }
+    .icon {
+      width: 80px;
+      height: 80px;
+      background: linear-gradient(135deg, #ef4444, #dc2626);
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 24px;
+      font-size: 40px;
+    }
+    h1 {
+      font-size: 28px;
+      color: #0f172a;
+      margin-bottom: 12px;
+      font-weight: 700;
+    }
+    p {
+      color: #475569;
+      margin-bottom: 32px;
+      font-size: 16px;
+    }
+    a {
+      display: inline-block;
+      background: linear-gradient(135deg, #3b82f6, #1e40af);
+      color: white;
+      text-decoration: none;
+      padding: 14px 32px;
+      border-radius: 8px;
+      font-weight: 600;
+      font-size: 16px;
+      transition: transform 0.2s, box-shadow 0.2s;
+    }
+    a:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 8px 20px rgba(59,130,246,0.4);
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="icon">⚠️</div>
+    <h1>${title}</h1>
+    <p>${message}</p>
+    ${caseUrl ? `<a href="${caseUrl}">Go to Case Page</a>` : `<a href="/">Go to Homepage</a>`}
+  </div>
+</body>
+</html>`;
+}
+
+function renderInfoPage(title: string, message: string, caseUrl: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${title} - AB Jail</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+      line-height: 1.6;
+      background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+    }
+    .container {
+      background: white;
+      border-radius: 16px;
+      box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+      max-width: 500px;
+      width: 100%;
+      padding: 40px;
+      text-align: center;
+    }
+    .icon {
+      width: 80px;
+      height: 80px;
+      background: linear-gradient(135deg, #f59e0b, #d97706);
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 24px;
+      font-size: 40px;
+    }
+    h1 {
+      font-size: 28px;
+      color: #0f172a;
+      margin-bottom: 12px;
+      font-weight: 700;
+    }
+    p {
+      color: #475569;
+      margin-bottom: 32px;
+      font-size: 16px;
+    }
+    a {
+      display: inline-block;
+      background: linear-gradient(135deg, #3b82f6, #1e40af);
+      color: white;
+      text-decoration: none;
+      padding: 14px 32px;
+      border-radius: 8px;
+      font-weight: 600;
+      font-size: 16px;
+      transition: transform 0.2s, box-shadow 0.2s;
+    }
+    a:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 8px 20px rgba(59,130,246,0.4);
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="icon">ℹ️</div>
+    <h1>${title}</h1>
+    <p>${message}</p>
+    <a href="${caseUrl}">View Case Details</a>
+  </div>
+</body>
+</html>`;
+}
+

--- a/web/src/server/db/schema.ts
+++ b/web/src/server/db/schema.ts
@@ -34,6 +34,11 @@ export const submissions = pgTable(
     landingScreenshotUrl: text("landing_screenshot_url"),
     landingRenderedAt: timestamp("landing_rendered_at", { withTimezone: true }),
     landingRenderStatus: text("landing_render_status"),
+    forwarderEmail: text("forwarder_email"),
+    submissionToken: text("submission_token"),
+    tokenUsedAt: timestamp("token_used_at", { withTimezone: true }),
+    previewEmailSentAt: timestamp("preview_email_sent_at", { withTimezone: true }),
+    previewEmailStatus: text("preview_email_status"),
   },
   (table) => {
     return {

--- a/web/src/server/ingest/save.ts
+++ b/web/src/server/ingest/save.ts
@@ -11,6 +11,8 @@ export type IngestTextParams = {
   imageUrlPlaceholder?: string;
   emailSubject?: string | null;
   emailBody?: string | null;
+  forwarderEmail?: string | null;
+  submissionToken?: string | null;
 };
 
 export type IngestResult = {
@@ -124,6 +126,12 @@ export async function ingestTextSubmission(params: IngestTextParams): Promise<In
   }
   if (params.emailBody) {
     insertRow.email_body = params.emailBody;
+  }
+  if (params.forwarderEmail) {
+    insertRow.forwarder_email = params.forwarderEmail;
+  }
+  if (params.submissionToken) {
+    insertRow.submission_token = params.submissionToken;
   }
 
   // Extract ActBlue landing URL (use raw text to catch all URLs)


### PR DESCRIPTION
Implements automatic email replies to users who forward messages to submit@abjail.org with a case preview and one-click submit button.

- Add forwarder_email and submission_token fields to track email submissions
- Generate secure 256-bit tokens for one-time report submission
- Send preview email after classification with campaign, violations, and action buttons
- Add /api/send-case-preview endpoint for email generation and sending
- Add /api/submit-report-via-email endpoint for handling email button clicks
- Automatically trigger preview emails from classify route (fire-and-forget)
- Natural filtering: only forwarded emails trigger preview, screenshots/pastes excluded
- Duplicate prevention: won't send multiple emails on re-classification
- Graceful error handling: email failures don't break case creation