### PR TITLE
fix: extract ActBlue URLs from original HTML before sanitization

### DIFF
--- a/web/src/app/api/inbound-email/route.ts
+++ b/web/src/app/api/inbound-email/route.ts
@@ -75,6 +75,9 @@ export async function POST(req: NextRequest) {
     // Note: cleanTextForAI also strips forwarded message headers
     const cleanedText = cleanTextForAI(rawText);
     
+    // IMPORTANT: Keep original HTML for URL extraction (before sanitization removes tracking links)
+    const originalHtml = bodyHtml;
+    
     // Sanitize HTML body (remove non-ActBlue links to protect honeytrap email)
     let sanitizedHtml = bodyHtml ? sanitizeEmailHtml(bodyHtml) : null;
     
@@ -102,7 +105,8 @@ export async function POST(req: NextRequest) {
       messageType: "email",
       imageUrlPlaceholder: "email://no-image",
       emailSubject: subject || null,
-      emailBody: sanitizedHtml || null, // Sanitized HTML (no tracking/unsubscribe links)
+      emailBody: sanitizedHtml || null, // Sanitized HTML (no tracking/unsubscribe links) for display
+      emailBodyOriginal: originalHtml || null, // Original HTML for URL extraction
       forwarderEmail: envelopeSender || null, // Email of person who forwarded
       submissionToken: submissionToken, // Secure token for email submission
     });


### PR DESCRIPTION
PROBLEM:
- sanitizeEmailHtml() removes tracking links to protect honeytrap
- URL extraction ran AFTER sanitization = no tracking links found
- Result: landingUrl always null, no screenshots triggered

SOLUTION:
- Keep original unsanitized HTML for URL extraction only
- Pass as separate emailBodyOriginal parameter
- Extract URLs from original, store sanitized for display
- Fixes automated screenshot pipeline for forwarded emails

Files changed:
- inbound-email: capture original HTML before sanitization
- ingest/save: add emailBodyOriginal param, prefer it for URL extraction

Test: Forward email, check logs for "extractActBlueUrl:following_redirects"