### PR TITLE
Improve ActBlue URL extraction with frequency-based CTA prioritization

### DIFF
--- a/web/EXTRACTION_ALGORITHM.md
+++ b/web/EXTRACTION_ALGORITHM.md
@@ -1,0 +1,246 @@
+# ActBlue Landing URL Extraction Algorithm
+
+## Overview
+
+This document describes the improved algorithm for extracting ActBlue landing page URLs from forwarded fundraising emails. The algorithm prioritizes CTA (call-to-action) tracking links over footer links by using frequency-based base counting and redirect resolution.
+
+## Algorithm Steps
+
+### 1. URL Extraction
+- Extract all URLs from both plain text and HTML `href` attributes
+- Clean trailing punctuation (`.`, `,`, `;`, `:`, `)`, `]`)
+- Apply blacklist filtering to skip:
+  - Unsubscribe/manage links (keywords: unsubscribe, optout, preferences, manage, etc.)
+  - Social media links (Facebook, Twitter, Instagram, LinkedIn, YouTube)
+  - `mailto:` links
+
+### 2. URL Categorization
+- **Direct ActBlue URLs**: URLs with `*.actblue.com` domains
+- **Non-ActBlue URLs**: Potential CTA tracking links that may redirect to ActBlue
+
+### 3. Base Normalization
+For each non-ActBlue URL, normalize to a "base" URL:
+- **Special handling for `/go/<id>` patterns**: Base = `origin + /go/<id>`
+  - Example: `https://act.example.org/go/11901?refcode=abc` → `https://act.example.org/go/11901`
+- **For other paths**: Base = `origin + normalized_pathname`
+  - Collapse multiple slashes (`//` → `/`)
+  - Remove trailing slashes
+  - Example: `https://example.org/donate/page` → `https://example.org/donate/page`
+
+### 4. Frequency Counting
+- Count occurrences of each base URL
+- Sort by frequency (descending), then by path length (longer = more specific)
+- This naturally prioritizes common CTA tracking links over footer links
+
+### 5. Top-5 Base Resolution
+For each of the top 5 bases by frequency (in order):
+1. Select up to 3 concrete URLs from that base
+2. For each URL, follow redirects:
+   - Try HEAD request first (3s timeout)
+   - Fall back to GET if HEAD doesn't return Location header
+   - Follow up to 5 hops
+   - Track redirect chain (domain → domain transitions)
+3. Check if final URL lands on `*.actblue.com`
+4. If found, return the ActBlue base (origin + pathname, no query params)
+5. If not, continue to next base
+
+### 6. Fallback to Direct ActBlue Links
+If none of the top 5 CTA bases resolve to ActBlue:
+- Count frequency of direct ActBlue base URLs
+- Return most common direct ActBlue base
+- This handles cases where:
+  - Only footer links exist
+  - CTA tracking servers are down/rate-limited
+  - CTA links have expired
+
+### 7. No Result
+If no ActBlue URLs found after all attempts, return `null`.
+
+## Why This Works
+
+### Frequency Naturally Prefers CTAs Over Footer
+In typical fundraising emails:
+- **CTA tracking links**: Appear 20-50 times (buttons, inline links, repeated CTAs)
+  - Example: `https://act.wedefendthevote.org/go/11901?...` appears ~30 times
+- **Footer links**: Appear 1-3 times (footer unsubscribe, settings, homepage)
+  - Example: `https://secure.actblue.com/donate/ms_dtv_footer_2025_mf` appears ~2 times
+
+By sorting bases by frequency and trying top 5 first:
+1. Most common CTA base (e.g., `/go/11901` × 30) is attempted first
+2. Redirects are followed: `act.wedefendthevote.org → secure.actblue.com/donate/ms_dtv_fr_q12025...`
+3. The fundraising-specific ActBlue page is found and selected
+4. Footer base is never needed (only used as fallback)
+
+### Guardrails
+- **Blacklist prevents accidents**: No unsubscribe/manage links are clicked
+- **Limited attempts**: Only top 5 bases, max 3 URLs per base, max 5 hops per URL
+- **Timeouts**: 3 seconds per HTTP request
+- **Fallback logic**: Direct ActBlue links used if CTA resolution fails
+
+## Logging
+
+The algorithm emits comprehensive structured logs for debugging:
+
+### `/api/inbound-email:html_extraction`
+```json
+{
+  "originalHtmlLength": 150000,
+  "hrefCount": 45,
+  "sampleHrefs": ["https://act.example.org/go/11901?...", ...]
+}
+```
+
+### `ingestTextSubmission:url_extraction_sources`
+```json
+{
+  "textLength": 5000,
+  "htmlLength": 150000,
+  "hrefUrlsExtracted": 45,
+  "hasOriginalHtml": true
+}
+```
+
+### `extractActBlueUrl:{id}:extractCandidates`
+```json
+{
+  "totalUrls": 50,
+  "sampleUrls": ["https://act.example.org/go/11901?...", ...]
+}
+```
+
+### `extractActBlueUrl:{id}:categorized`
+```json
+{
+  "directActBlue": 3,
+  "nonActBlue": 35,
+  "skipped": 12,
+  "skippedReasons": [
+    {"url": "mailto:...", "reason": "mailto"},
+    {"url": "https://.../unsubscribe", "reason": "blacklist:unsubscribe"}
+  ]
+}
+```
+
+### `extractActBlueUrl:{id}:baseCounts`
+```json
+{
+  "totalBases": 8,
+  "top10": [
+    {"base": "https://act.example.org/go/11901", "count": 30, "sampleUrl": "..."},
+    {"base": "https://secure.actblue.com/donate/ms_dtv_footer_2025_mf", "count": 2, "sampleUrl": "..."}
+  ]
+}
+```
+
+### `extractActBlueUrl:{id}:pickingOrder`
+```json
+{
+  "bases": [
+    "https://act.example.org/go/11901",
+    "https://example.org/action/donate",
+    ...
+  ]
+}
+```
+
+### `extractActBlueUrl:{id}:redirectAttempt`
+```json
+{
+  "base": "https://act.example.org/go/11901",
+  "count": 30,
+  "urlsToTry": 3
+}
+```
+
+### `extractActBlueUrl:{id}:redirectAttempt:result`
+```json
+{
+  "base": "https://act.example.org/go/11901",
+  "url": "https://act.example.org/go/11901?refcode=abc",
+  "hops": [
+    "act.example.org → secure.actblue.com",
+    "final(200)"
+  ],
+  "status": "success",
+  "finalUrl": "https://secure.actblue.com/donate/ms_dtv_fr_q12025-no-kings-act-2x-mg?..."
+}
+```
+
+### `extractActBlueUrl:{id}:selectionOutcome` (Success)
+```json
+{
+  "outcome": "success",
+  "selectedBase": "https://secure.actblue.com/donate/ms_dtv_fr_q12025-no-kings-act-2x-mg",
+  "sourceBase": "https://act.example.org/go/11901",
+  "sourceBaseCount": 30,
+  "hops": ["act.example.org → secure.actblue.com", "final(200)"]
+}
+```
+
+### `extractActBlueUrl:{id}:selectionOutcome` (Fallback)
+```json
+{
+  "outcome": "fallback_to_direct",
+  "selectedBase": "https://secure.actblue.com/donate/ms_dtv_footer_2025_mf",
+  "directActBlueCount": 2,
+  "reason": "no_cta_bases_resolved"
+}
+```
+
+### `extractActBlueUrl:{id}:selectionOutcome` (None Found)
+```json
+{
+  "outcome": "none_found",
+  "reason": "no_actblue_urls_after_all_attempts"
+}
+```
+
+## Files Modified
+
+1. **`web/src/app/api/inbound-email/route.ts`**
+   - Added logging for originalHtml extraction metrics
+   - Logs href count and sample hrefs before sanitization
+
+2. **`web/src/server/ingest/save.ts`**
+   - Complete rewrite of `extractActBlueUrl()` function
+   - Added `normalizeToBase()` helper with `/go/<id>` handling
+   - Added `shouldSkipUrl()` blacklist checker
+   - Updated `followRedirect()` to return structured result with hops
+   - Added comprehensive logging at every step
+   - Implemented frequency-based top-5 base resolution
+   - Added fallback to direct ActBlue links
+
+## Testing Scenarios
+
+### Scenario 1: Defend the Vote PAC (CTA-heavy email)
+**Expected:**
+- `baseCounts` shows `https://act.wedefendthevote.org/go/11901` count ≈ 30
+- Footer base `https://secure.actblue.com/donate/ms_dtv_footer_2025_mf` count ≈ 3
+- `pickingOrder` tries `/go/11901` first
+- `redirectAttempt` shows hops: `act.wedefendthevote.org → secure.actblue.com`
+- `selectionOutcome` selects fundraising base (not footer)
+
+### Scenario 2: Footer-only email
+**Expected:**
+- `baseCounts` shows only footer ActBlue base(s)
+- `pickingOrder` is empty (no non-ActBlue bases)
+- `selectionOutcome` selects most common direct ActBlue base
+
+### Scenario 3: Expired/rate-limited CTA trackers
+**Expected:**
+- `redirectAttempt` logs failures (timeout, 404, etc.)
+- `selectionOutcome` falls back to direct ActBlue footer base
+
+### Scenario 4: No ActBlue links
+**Expected:**
+- `selectionOutcome` returns `none_found`
+- `landing_url` is NULL in database
+
+## Benefits
+
+1. **Accurate fundraising page detection**: Finds the actual CTA landing page, not generic footer links
+2. **Transparent debugging**: Every decision is logged with clear reasoning
+3. **Robust fallback logic**: Handles edge cases (tracker failures, footer-only emails)
+4. **Safe operation**: Blacklist prevents clicking unsubscribe/manage links
+5. **Performance-bounded**: Limits on bases/URLs/hops/timeouts prevent runaway execution
+

--- a/web/src/app/api/inbound-email/route.ts
+++ b/web/src/app/api/inbound-email/route.ts
@@ -78,6 +78,17 @@ export async function POST(req: NextRequest) {
     // IMPORTANT: Keep original HTML for URL extraction (before sanitization removes tracking links)
     const originalHtml = bodyHtml;
     
+    // Log HTML extraction metrics for debugging
+    if (originalHtml) {
+      const hrefPattern = /href=["']([^"']+)["']/gi;
+      const hrefMatches = Array.from(originalHtml.matchAll(hrefPattern));
+      console.log("/api/inbound-email:html_extraction", {
+        originalHtmlLength: originalHtml.length,
+        hrefCount: hrefMatches.length,
+        sampleHrefs: hrefMatches.slice(0, 5).map(m => m[1])
+      });
+    }
+    
     // Sanitize HTML body (remove non-ActBlue links to protect honeytrap email)
     let sanitizedHtml = bodyHtml ? sanitizeEmailHtml(bodyHtml) : null;
     

--- a/web/src/server/ingest/save.ts
+++ b/web/src/server/ingest/save.ts
@@ -58,8 +58,78 @@ function computeHeuristic(text: string): { isFundraising: boolean; score: number
   return { isFundraising, score: score + (hasDollar ? 1 : 0), hits };
 }
 
+// Blacklist keywords for URLs to skip (unsubscribe, preferences, social, etc.)
+const URL_BLACKLIST_KEYWORDS = [
+  "unsubscribe", "unsub", "optout", "opt-out",
+  "emailpref", "email-prefs", "preferences", "prefs",
+  "manage", "manage-subscriptions", "update-profile"
+];
+
+const SOCIAL_HOSTS = [
+  "facebook.com", "twitter.com", "x.com", "instagram.com", 
+  "youtube.com", "linkedin.com"
+];
+
+// Check if URL should be skipped (blacklist)
+function shouldSkipUrl(url: string): { skip: boolean; reason?: string } {
+  const urlLower = url.toLowerCase();
+  
+  if (urlLower.startsWith("mailto:")) {
+    return { skip: true, reason: "mailto" };
+  }
+  
+  for (const keyword of URL_BLACKLIST_KEYWORDS) {
+    if (urlLower.includes(keyword)) {
+      return { skip: true, reason: `blacklist:${keyword}` };
+    }
+  }
+  
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    for (const social of SOCIAL_HOSTS) {
+      if (host.includes(social)) {
+        return { skip: true, reason: `social:${social}` };
+      }
+    }
+  } catch {
+    // Invalid URL
+    return { skip: true, reason: "invalid_url" };
+  }
+  
+  return { skip: false };
+}
+
+// Normalize URL to base (origin + normalized path)
+// Special handling for /go/<id> patterns
+function normalizeToBase(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const origin = parsed.origin;
+    const path = parsed.pathname;
+    
+    // Special case: /go/<id> or similar tracking patterns
+    const goMatch = path.match(/^(\/go\/[^\/]+)/i);
+    if (goMatch) {
+      return origin + goMatch[1];
+    }
+    
+    // Otherwise: origin + full pathname (normalized)
+    const normalized = path
+      .replace(/\/+/g, "/") // collapse multiple slashes
+      .replace(/\/$/, "");   // remove trailing slash
+    
+    return origin + (normalized || "/");
+  } catch {
+    return null;
+  }
+}
+
 // Follow redirects to resolve tracking URLs (async helper)
-async function followRedirect(url: string, maxHops = 5): Promise<string | null> {
+// Returns { finalUrl, hops, status } where hops = array of domain transitions
+async function followRedirect(
+  url: string, 
+  maxHops = 5
+): Promise<{ finalUrl: string | null; hops: string[]; status: string }> {
   let current = url;
   const hops: string[] = [];
   
@@ -85,178 +155,237 @@ async function followRedirect(url: string, maxHops = 5): Promise<string | null> 
       const location = res.headers.get("location");
       if (!location) {
         // No redirect header - this is the final destination
-        hops.push(`${i}: final(${res.status})`);
-        if (i === 0) {
-          // First request returned no redirect - might be expired/broken link
-          console.log("followRedirect:no_redirect", { url, status: res.status, hops });
-        }
-        return current;
+        hops.push(`final(${res.status})`);
+        return { finalUrl: current, hops, status: "success" };
       }
       
       const next = new URL(location, current).href;
-      hops.push(`${i}: ${new URL(current).hostname} -> ${new URL(next).hostname}`);
+      hops.push(`${new URL(current).hostname} → ${new URL(next).hostname}`);
       current = next;
     } catch (e) {
       // Log WHY it failed
       const error = e instanceof Error ? e.message : String(e);
-      hops.push(`${i}: ERROR(${error})`);
-      console.log("followRedirect:failed", { url, hops, error });
-      return null; // Network error or timeout
+      hops.push(`ERROR(${error})`);
+      return { finalUrl: null, hops, status: "error" };
     }
   }
   
-  console.log("followRedirect:max_hops", { url, hops });
-  return current; // Max hops reached
+  hops.push(`MAX_HOPS(${maxHops})`);
+  return { finalUrl: current, hops, status: "max_hops" };
 }
 
-async function extractActBlueUrl(text: string): Promise<string | null> {
+/**
+ * Extract ActBlue landing URL from combined text + HTML links
+ * New algorithm:
+ * 1. Extract all URLs from text (plain + HTML hrefs)
+ * 2. Normalize to base (origin + first path segments, special handling for /go/<id>)
+ * 3. Count frequency of each base (pure frequency, no weighting)
+ * 4. Try top 5 bases by frequency, follow redirects until ActBlue found
+ * 5. Fall back to direct ActBlue links if no CTA bases resolve
+ */
+async function extractActBlueUrl(
+  text: string, 
+  submissionId?: string
+): Promise<string | null> {
+  const logPrefix = submissionId ? `extractActBlueUrl:${submissionId}` : "extractActBlueUrl";
+  
+  // Step 1: Extract all URLs from text
   const urlPattern = /https?:\/\/[^\s<>"'\)]+/g;
-  const matches = text.match(urlPattern) || [];
+  const rawMatches = text.match(urlPattern) || [];
+  
+  // Clean trailing punctuation
+  const allUrls = rawMatches
+    .map(url => url.replace(/[.,;:)\]]+$/, ""))
+    .filter(url => url.length > 0);
+  
+  console.log(`${logPrefix}:extractCandidates`, {
+    totalUrls: allUrls.length,
+    sampleUrls: allUrls.slice(0, 5)
+  });
+  
+  if (allUrls.length === 0) {
+    return null;
+  }
+  
+  // Step 2: Categorize URLs and normalize to bases
   const directActBlueUrls: string[] = [];
-  const resolvedActBlueUrls: string[] = [];
-  const trackingUrls: string[] = [];
-
-  for (const rawUrl of matches) {
+  const nonActBlueUrls: string[] = [];
+  const skippedUrls: Array<{ url: string; reason: string }> = [];
+  
+  for (const url of allUrls) {
+    // Check blacklist
+    const skipCheck = shouldSkipUrl(url);
+    if (skipCheck.skip) {
+      skippedUrls.push({ url, reason: skipCheck.reason || "unknown" });
+      continue;
+    }
+    
     try {
-      // Clean trailing punctuation
-      const cleaned = rawUrl.replace(/[.,;:)\]]+$/, "");
-      const parsed = new URL(cleaned);
+      const parsed = new URL(url);
       const host = parsed.hostname.toLowerCase();
 
       // Direct ActBlue domain
       if (host === "actblue.com" || host.endsWith(".actblue.com")) {
-        directActBlueUrls.push(cleaned);
-      }
-      // Treat any non-ActBlue link as a candidate tracking redirect, with safe blacklists
-      else {
-        const urlLower = cleaned.toLowerCase();
-        // Skip obvious non-donation/action links
-        if (urlLower.startsWith("mailto:")) continue;
-        // Strong unsubscribe/preferences blacklist (paths, params, or hostnames)
-        const unsubKeywords = [
-          "unsubscribe", "unsub", "optout", "opt-out",
-          "emailpref", "email-prefs", "preferences", "prefs",
-          "manage", "manage-subscriptions", "update-profile"
-        ];
-        if (unsubKeywords.some(k => urlLower.includes(k))) continue;
-        if (host.includes("facebook.com") || host.includes("twitter.com") || host.includes("x.com") || host.includes("instagram.com") || host.includes("youtube.com") || host.includes("linkedin.com")) continue;
-        trackingUrls.push(cleaned);
+        directActBlueUrls.push(url);
+      } else {
+        nonActBlueUrls.push(url);
       }
     } catch {
-      continue; // Invalid URL, skip
+      skippedUrls.push({ url, reason: "invalid_url" });
     }
   }
-
-  // Always attempt to resolve tracking URLs (CTA links) even if footer ActBlue links are present
-  if (trackingUrls.length > 0) {
-    // Limit concurrent redirect checks to avoid overwhelming the network
-    const urlsToCheck = trackingUrls.slice(0, 20); // Max 20 URLs
-    console.log("extractActBlueUrl:following_redirects", { 
-      total: trackingUrls.length, 
-      checking: urlsToCheck.length,
-      sample: urlsToCheck.slice(0, 3).map(u => new URL(u).hostname)
-    });
+  
+  console.log(`${logPrefix}:categorized`, {
+    directActBlue: directActBlueUrls.length,
+    nonActBlue: nonActBlueUrls.length,
+    skipped: skippedUrls.length,
+    skippedReasons: skippedUrls.slice(0, 3)
+  });
+  
+  // Step 3: Build frequency map of bases (non-ActBlue URLs = potential CTA tracking links)
+  const baseFrequency = new Map<string, { count: number; sampleUrls: string[] }>();
+  
+  for (const url of nonActBlueUrls) {
+    const base = normalizeToBase(url);
+    if (!base) continue;
     
-    const resolved = await Promise.allSettled(
-      urlsToCheck.map(async (url) => {
-        const final = await followRedirect(url);
-        if (!final) return null;
-        try {
-          const u = new URL(final);
-          const host = u.hostname.toLowerCase();
-          if (host === "actblue.com" || host.endsWith(".actblue.com")) {
-            // Filter out unsubscribe/manage links
-            if (u.pathname.includes("unsubscribe") || u.pathname.includes("manage") || u.pathname.includes("preferences")) {
-              return null;
-            }
-            return final;
-          }
-        } catch {}
-        return null;
-      })
-    );
-    
-    for (const result of resolved) {
-      if (result.status === "fulfilled" && result.value) {
-        resolvedActBlueUrls.push(result.value);
+    const existing = baseFrequency.get(base);
+    if (existing) {
+      existing.count++;
+      if (existing.sampleUrls.length < 3) {
+        existing.sampleUrls.push(url);
       }
+    } else {
+      baseFrequency.set(base, { count: 1, sampleUrls: [url] });
     }
-    console.log("extractActBlueUrl:redirects_resolved", { 
-      found: resolvedActBlueUrls.length,
-      samples: resolvedActBlueUrls.slice(0, 2)
+  }
+  
+  // Sort bases by frequency (descending), then by path length (longer = more specific)
+  const sortedBases = Array.from(baseFrequency.entries())
+    .map(([base, stats]) => ({
+      base,
+      count: stats.count,
+      sampleUrl: stats.sampleUrls[0],
+      sampleUrls: stats.sampleUrls,
+      pathLength: base.split("/").length
+    }))
+    .sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      return b.pathLength - a.pathLength;
+    });
+  
+  console.log(`${logPrefix}:baseCounts`, {
+    totalBases: sortedBases.length,
+    top10: sortedBases.slice(0, 10).map(b => ({
+      base: b.base,
+      count: b.count,
+      sampleUrl: b.sampleUrl
+    }))
+  });
+  
+  // Step 4: Try top 5 bases by frequency, follow redirects
+  const TOP_N_BASES = 5;
+  const MAX_URLS_PER_BASE = 3; // Try up to 3 concrete URLs per base
+  const topBases = sortedBases.slice(0, TOP_N_BASES);
+  
+  if (topBases.length > 0) {
+    console.log(`${logPrefix}:pickingOrder`, {
+      bases: topBases.map(b => b.base)
     });
   }
-
-  const totalFound = directActBlueUrls.length + resolvedActBlueUrls.length;
-  if (totalFound === 0) return null;
-  if (totalFound === 1) {
-    // Always return base URL (no params)
-    try {
-      const single = directActBlueUrls[0] || resolvedActBlueUrls[0];
-      const u = new URL(single as string);
-      return `${u.origin}${u.pathname}`;
-    } catch {
-      return (directActBlueUrls[0] || resolvedActBlueUrls[0]) as string;
-    }
-  }
-
-  // Build weighted stats by BASE URL (origin + pathname)
-  // - resolved links (from tracking) are weighted higher (CTA signals)
-  // - cap direct counts to avoid footer repetition dominating
-  // - penalize obvious footer paths
-  type BaseStats = { direct: number; resolved: number; withParams: number; pathLength: number; hasFooter: boolean };
-  const baseStats = new Map<string, BaseStats>();
-
-  const addUrlToStats = (url: string, kind: "direct" | "resolved") => {
-    try {
-      const parsed = new URL(url);
-      const baseUrl = `${parsed.origin}${parsed.pathname}`;
-      const hadParams = parsed.searchParams && Array.from(parsed.searchParams.keys()).length > 0;
-      const prev = baseStats.get(baseUrl) || { direct: 0, resolved: 0, withParams: 0, pathLength: parsed.pathname.length, hasFooter: /footer/i.test(parsed.pathname) };
-      baseStats.set(baseUrl, {
-        direct: prev.direct + (kind === "direct" ? 1 : 0),
-        resolved: prev.resolved + (kind === "resolved" ? 1 : 0),
-        withParams: prev.withParams + (hadParams ? 1 : 0),
-        pathLength: prev.pathLength,
-        hasFooter: prev.hasFooter || /footer/i.test(parsed.pathname),
+  
+  for (const baseInfo of topBases) {
+    const urlsToTry = baseInfo.sampleUrls.slice(0, MAX_URLS_PER_BASE);
+    
+    console.log(`${logPrefix}:redirectAttempt`, {
+      base: baseInfo.base,
+      count: baseInfo.count,
+      urlsToTry: urlsToTry.length
+    });
+    
+    for (const url of urlsToTry) {
+      const redirectResult = await followRedirect(url, 5);
+      
+      console.log(`${logPrefix}:redirectAttempt:result`, {
+        base: baseInfo.base,
+        url: url.slice(0, 100),
+        hops: redirectResult.hops,
+        status: redirectResult.status,
+        finalUrl: redirectResult.finalUrl?.slice(0, 100)
       });
-    } catch {
-      // ignore
+      
+      // Check if final URL is ActBlue
+      if (redirectResult.finalUrl) {
+        try {
+          const finalParsed = new URL(redirectResult.finalUrl);
+          const finalHost = finalParsed.hostname.toLowerCase();
+          
+          if (finalHost === "actblue.com" || finalHost.endsWith(".actblue.com")) {
+            // Success! This base resolves to ActBlue
+            const actblueBase = `${finalParsed.origin}${finalParsed.pathname}`;
+            
+            console.log(`${logPrefix}:selectionOutcome`, {
+              outcome: "success",
+              selectedBase: actblueBase,
+              sourceBase: baseInfo.base,
+              sourceBaseCount: baseInfo.count,
+              hops: redirectResult.hops
+            });
+            
+            return actblueBase;
+          }
+        } catch {
+          // Invalid final URL, continue
+        }
+      }
     }
-  };
-
-  for (const url of directActBlueUrls) addUrlToStats(url, "direct");
-  for (const url of resolvedActBlueUrls) addUrlToStats(url, "resolved");
-
-  if (baseStats.size === 0) return null;
-
-  // Compute weighted score per base
-  const candidates = Array.from(baseStats.entries()).map(([base, s]) => {
-    const cappedDirect = Math.min(s.direct, 2);
-    const footerPenalty = s.hasFooter ? 2 : 0;
-    const score = s.resolved * 3 + cappedDirect - footerPenalty;
-    return { base, score, stats: s };
-  });
-
-  candidates.sort((a, b) => {
-    if (b.score !== a.score) return b.score - a.score;
-    if (b.stats.resolved !== a.stats.resolved) return b.stats.resolved - a.stats.resolved;
-    if (b.stats.pathLength !== a.stats.pathLength) return b.stats.pathLength - a.stats.pathLength;
-    if (b.stats.withParams !== a.stats.withParams) return b.stats.withParams - a.stats.withParams;
-    return a.base.localeCompare(b.base);
-  });
-
-  const best = candidates[0];
-  if (best) {
-    console.log("extractActBlueUrl:base_selected", {
-      base: best.base,
-      score: best.score,
-      direct: best.stats.direct,
-      resolved: best.stats.resolved,
-      footer: best.stats.hasFooter,
+    
+    // No URLs from this base resolved to ActBlue, try next base
+    console.log(`${logPrefix}:redirectAttempt:base_failed`, {
+      base: baseInfo.base,
+      reason: "no_actblue_resolution"
     });
-    return best.base;
   }
+  
+  // Step 5: No CTA bases resolved to ActBlue, fall back to direct ActBlue links
+  if (directActBlueUrls.length > 0) {
+    // Count frequency of direct ActBlue bases
+    const directBaseFrequency = new Map<string, number>();
+    
+    for (const url of directActBlueUrls) {
+      try {
+        const parsed = new URL(url);
+        const base = `${parsed.origin}${parsed.pathname}`;
+        directBaseFrequency.set(base, (directBaseFrequency.get(base) || 0) + 1);
+    } catch {
+        // Invalid URL, skip
+      }
+    }
+    
+    // Pick most common direct ActBlue base
+    const sortedDirectBases = Array.from(directBaseFrequency.entries())
+      .sort((a, b) => b[1] - a[1]);
+    
+    if (sortedDirectBases.length > 0) {
+      const [base, count] = sortedDirectBases[0];
+      
+      console.log(`${logPrefix}:selectionOutcome`, {
+        outcome: "fallback_to_direct",
+        selectedBase: base,
+        directActBlueCount: count,
+        reason: "no_cta_bases_resolved"
+      });
+      
+      return base;
+    }
+  }
+  
+  // No ActBlue URLs found at all
+  console.log(`${logPrefix}:selectionOutcome`, {
+    outcome: "none_found",
+    reason: "no_actblue_urls_after_all_attempts"
+  });
+  
   return null;
 }
 
@@ -309,14 +438,26 @@ export async function ingestTextSubmission(params: IngestTextParams): Promise<In
   // Use ORIGINAL unsanitized HTML for URL extraction (sanitized HTML has tracking links removed)
   let textWithHtmlLinks = textForDedupe || "";
   const htmlForExtraction = params.emailBodyOriginal || params.emailBody; // Prefer original, fallback to sanitized
+  
+  let hrefUrlsCount = 0;
   if (htmlForExtraction) {
     // Extract href URLs from HTML using regex
     const hrefPattern = /href=["']([^"']+)["']/gi;
     const hrefMatches = htmlForExtraction.matchAll(hrefPattern);
-    const hrefUrls = Array.from(hrefMatches, m => m[1]).join(" ");
-    textWithHtmlLinks = textWithHtmlLinks + " " + hrefUrls;
+    const hrefUrls = Array.from(hrefMatches, m => m[1]);
+    hrefUrlsCount = hrefUrls.length;
+    textWithHtmlLinks = textWithHtmlLinks + " " + hrefUrls.join(" ");
   }
   
+  console.log("ingestTextSubmission:url_extraction_sources", {
+    textLength: (textForDedupe || "").length,
+    htmlLength: htmlForExtraction ? htmlForExtraction.length : 0,
+    hrefUrlsExtracted: hrefUrlsCount,
+    hasOriginalHtml: !!params.emailBodyOriginal
+  });
+  
+  // Note: We'll get a submission ID after insert, but we can pass null for now
+  // The extraction function will use a generic log prefix
   const landingUrl = await extractActBlueUrl(textWithHtmlLinks);
   if (landingUrl) {
     insertRow.landing_url = landingUrl;


### PR DESCRIPTION
- Rewrite extractActBlueUrl() to use frequency-based base counting
- Normalize URLs to base (origin + path) with special /go/<id> handling
- Try top 5 bases by frequency, follow redirects to find ActBlue landing page
- Fall back to direct ActBlue links if CTA bases fail to resolve
- Add comprehensive structured logging at every extraction step
- Add blacklist for unsubscribe/manage/social links
- Add guardrails: max 5 bases, 3 URLs per base, 5 hops per URL, 3s timeout
- Log HTML extraction metrics in inbound-email route
- Add EXTRACTION_ALGORITHM.md documentation

This fixes the issue where footer ActBlue links were selected instead of
the most common CTA tracking links in emails like Defend the Vote PAC.