### PR TITLE
Fix ngpvan click tracker support: handle HTTP 405 responses

### DIFF
--- a/web/EXTRACTION_ALGORITHM.md
+++ b/web/EXTRACTION_ALGORITHM.md
@@ -37,7 +37,9 @@ For each of the top 5 bases by frequency (in order):
 1. Select up to 3 concrete URLs from that base
 2. For each URL, follow redirects:
    - Try HEAD request first (3s timeout)
-   - Fall back to GET if HEAD doesn't return Location header
+   - Fall back to GET if:
+     - HEAD returns 405 Method Not Allowed (common for ngpvan/click trackers)
+     - HEAD returns 3xx without Location header (malformed redirect)
    - Follow up to 5 hops
    - Track redirect chain (domain → domain transitions)
 3. Check if final URL lands on `*.actblue.com`


### PR DESCRIPTION
NGP VAN click tracking URLs (click.ngpvan.com) return 405 Method Not Allowed for HEAD requests. Updated followRedirect() to automatically fall back to GET when receiving 405, in addition to existing 3xx fallback logic.

This fixes House Majority PAC and other campaigns using NGP VAN's email platform, allowing their CTA links to properly resolve to ActBlue landing pages.

Tested with curl:
- HEAD request returns 405 + 'allow: GET' header
- GET request returns 302 redirect to secure.actblue.com/donate/hmp-email-2025
- Final ActBlue page returns 200 OK
- Redirect chain verified: click.ngpvan.com → secure.actblue.com

Logs will now show 'HEAD:405→GET' in hop trace when fallback occurs.