### PR TITLE
Fix Report History landing page URL display

### DIFF
--- a/web/src/app/cases/[id]/client.tsx
+++ b/web/src/app/cases/[id]/client.tsx
@@ -453,7 +453,7 @@ function renderReportBody(body: string) {
     // skip underline line right after title if present
     let start = idx + 1;
     if (lines[start] && /^[-_]{3,}$/.test(lines[start].trim())) start++;
-    const nextTitleIdx = lines.findIndex((l, i) => i > idx && /^(Campaign\/Org|Summary|Violations|Landing page URL|Landing page|Reporter note|Screenshot|Meta)\s*$/i.test(l.trim()));
+    const nextTitleIdx = lines.findIndex((l, i) => i > idx && /^(Campaign\/Org|Summary|Violations|Landing page URL|Landing page|Email HTML|Reporter note|Screenshot|Meta)\s*$/i.test(l.trim()));
     const end = nextTitleIdx === -1 ? lines.length : nextTitleIdx;
     return lines.slice(start, end);
   };


### PR DESCRIPTION
The landing page URL in the Report History card was showing HTML content concatenated to it (e.g., 'url Email HTML --------- url').

This was caused by the section parser not recognizing 'Email HTML' as a section boundary, so it included that section's content as part of the landing page URL.

Added 'Email HTML' to the recognized section titles regex so the parser correctly stops at that boundary.