### PR TITLE
Add email_from field to store raw From line for AB009 detection

### DIFF
--- a/web/sql/2025-10-12_add_email_from.sql
+++ b/web/sql/2025-10-12_add_email_from.sql
@@ -1,0 +1,9 @@
+-- Add email_from field to store raw "From" line from email headers
+-- This is distinct from sender_name (extracted entity name) and sender_id (extracted email)
+-- Example: "NEW ActBlue Update (via dccc@dccc.org) <dccc@ak.dccc.org>"
+
+alter table submissions
+add column if not exists email_from text;
+
+comment on column submissions.email_from is 'Raw From line from email header (e.g., "Name <email@example.com>"). Distinct from sender_name (AI-extracted entity) and sender_id (extracted email address).';
+

--- a/web/src/app/api/inbound-email/route.ts
+++ b/web/src/app/api/inbound-email/route.ts
@@ -118,6 +118,7 @@ export async function POST(req: NextRequest) {
       emailSubject: subject || null,
       emailBody: sanitizedHtml || null, // Sanitized HTML (no tracking/unsubscribe links) for display
       emailBodyOriginal: originalHtml || null, // Original HTML for URL extraction
+      emailFrom: sender || null, // Raw "From" line from Mailgun (e.g., "NEW ActBlue Update <dccc@ak.dccc.org>")
       forwarderEmail: envelopeSender || null, // Email of person who forwarded
       submissionToken: submissionToken, // Secure token for email submission
     });

--- a/web/src/server/ai/classify.ts
+++ b/web/src/server/ai/classify.ts
@@ -21,13 +21,13 @@ export async function runClassification(submissionId: string, opts: RunClassific
   // Load submission
   const { data: items, error } = await supabase
     .from("submissions")
-    .select("id, image_url, raw_text, landing_url, landing_screenshot_url, sender_id, sender_name")
+    .select("id, image_url, raw_text, landing_url, landing_screenshot_url, email_from")
     .eq("id", submissionId)
     .limit(1);
   if (error || !items?.[0]) {
     return { ok: false, status: 404, error: "not_found" as const };
   }
-  const sub = items[0] as { id: string; image_url?: string | null; raw_text?: string | null; landing_url?: string | null; landing_screenshot_url?: string | null; sender_id?: string | null; sender_name?: string | null };
+  const sub = items[0] as { id: string; image_url?: string | null; raw_text?: string | null; landing_url?: string | null; landing_screenshot_url?: string | null; email_from?: string | null };
 
   // Prepare signed image URL if applicable (and only if extension is supported by OpenAI image_url)
   let signedUrl: string | null = null;
@@ -75,10 +75,10 @@ export async function runClassification(submissionId: string, opts: RunClassific
 
   type Message = { role: "system" | "user"; content: any };
   
-  // Build the initial message text with sender info and body
+  // Build the initial message text with raw From line and body
   let messageText = "";
-  if (sub.sender_name || sub.sender_id) {
-    messageText += `Sender: ${sub.sender_name || sub.sender_id}\n\n`;
+  if (sub.email_from) {
+    messageText += `From: ${sub.email_from}\n\n`;
   }
   messageText += String(sub.raw_text || "").trim() || "(none)";
   

--- a/web/src/server/db/schema.ts
+++ b/web/src/server/db/schema.ts
@@ -30,6 +30,7 @@ export const submissions = pgTable(
     aiSummary: text("ai_summary"),
     emailSubject: text("email_subject"),
     emailBody: text("email_body"),
+    emailFrom: text("email_from"),
     isPublic: boolean("public").default(true),
     landingUrl: text("landing_url"),
     landingScreenshotUrl: text("landing_screenshot_url"),

--- a/web/src/server/ingest/save.ts
+++ b/web/src/server/ingest/save.ts
@@ -12,6 +12,7 @@ export type IngestTextParams = {
   emailSubject?: string | null;
   emailBody?: string | null; // Sanitized HTML for display
   emailBodyOriginal?: string | null; // Original unsanitized HTML for URL extraction
+  emailFrom?: string | null; // Raw "From" line from email header (e.g., "Name <email@example.com>")
   forwarderEmail?: string | null;
   submissionToken?: string | null;
   mediaUrls?: Array<{ url: string; contentType?: string }>;
@@ -434,6 +435,9 @@ export async function ingestTextSubmission(params: IngestTextParams): Promise<In
   }
   if (params.emailBody) {
     insertRow.email_body = params.emailBody;
+  }
+  if (params.emailFrom) {
+    insertRow.email_from = params.emailFrom;
   }
   if (params.forwarderEmail) {
     insertRow.forwarder_email = params.forwarderEmail;


### PR DESCRIPTION
- Added email_from column to submissions table (migration)
- Store raw 'From' line from Mailgun (e.g., 'NEW ActBlue Update <email>')
- Updated classify.ts to use email_from instead of sender_name
- email_from is the RAW from line, sender_name is AI-extracted entity name
- This allows AB009 detection to see deceptive sender names