### PR TITLE
feat: Add AI-powered PII redaction for email and SMS submissions

### DIFF
--- a/web/src/app/api/redact-pii/route.ts
+++ b/web/src/app/api/redact-pii/route.ts
@@ -1,0 +1,175 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase-server";
+import { detectPII } from "@/server/ai/redact-pii";
+
+/**
+ * Redact PII from submission text fields.
+ * Runs as a separate step after classification/sender extraction.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { submissionId } = body;
+
+    if (!submissionId || typeof submissionId !== "string") {
+      return NextResponse.json(
+        { error: "submissionId required" },
+        { status: 400 }
+      );
+    }
+
+    console.log("redact-pii:start", { submissionId });
+
+    const supabase = getSupabaseServer();
+
+    // Load submission data
+    const { data: items, error: fetchError } = await supabase
+      .from("submissions")
+      .select("id, raw_text, email_body, email_subject, email_from")
+      .eq("id", submissionId)
+      .limit(1);
+
+    if (fetchError || !items?.[0]) {
+      console.error("redact-pii:not_found", { submissionId, error: fetchError });
+      return NextResponse.json(
+        { error: "submission not found" },
+        { status: 404 }
+      );
+    }
+
+    const submission = items[0] as {
+      id: string;
+      raw_text?: string | null;
+      email_body?: string | null;
+      email_subject?: string | null;
+      email_from?: string | null;
+    };
+
+    // Detect PII using AI
+    const piiResult = await detectPII(
+      submission.raw_text || "",
+      submission.email_from
+    );
+
+    console.log("redact-pii:detected", {
+      submissionId,
+      hasName: !!piiResult.name,
+      hasEmail: !!piiResult.email,
+      confidence: piiResult.confidence,
+    });
+
+    // If no PII detected or low confidence, skip redaction
+    if ((!piiResult.name && !piiResult.email) || piiResult.confidence < 0.5) {
+      console.log("redact-pii:skipped", {
+        submissionId,
+        reason: "no_pii_or_low_confidence",
+        confidence: piiResult.confidence,
+      });
+      return NextResponse.json({
+        ok: true,
+        redacted: false,
+        reason: "no_pii_detected",
+        confidence: piiResult.confidence,
+      });
+    }
+
+    // Perform redaction on text fields
+    const updates: Record<string, string | null> = {};
+
+    if (submission.raw_text) {
+      let redactedText = submission.raw_text;
+      
+      if (piiResult.name) {
+        const nameAsterisks = "*".repeat(piiResult.name.length);
+        redactedText = redactedText.split(piiResult.name).join(nameAsterisks);
+      }
+      
+      if (piiResult.email) {
+        const emailAsterisks = "*".repeat(piiResult.email.length);
+        redactedText = redactedText.split(piiResult.email).join(emailAsterisks);
+      }
+      
+      updates.raw_text = redactedText;
+    }
+
+    if (submission.email_body) {
+      let redactedBody = submission.email_body;
+      
+      if (piiResult.name) {
+        const nameAsterisks = "*".repeat(piiResult.name.length);
+        redactedBody = redactedBody.split(piiResult.name).join(nameAsterisks);
+      }
+      
+      if (piiResult.email) {
+        const emailAsterisks = "*".repeat(piiResult.email.length);
+        redactedBody = redactedBody.split(piiResult.email).join(emailAsterisks);
+      }
+      
+      updates.email_body = redactedBody;
+    }
+
+    if (submission.email_subject) {
+      let redactedSubject = submission.email_subject;
+      
+      if (piiResult.name) {
+        const nameAsterisks = "*".repeat(piiResult.name.length);
+        redactedSubject = redactedSubject.split(piiResult.name).join(nameAsterisks);
+      }
+      
+      if (piiResult.email) {
+        const emailAsterisks = "*".repeat(piiResult.email.length);
+        redactedSubject = redactedSubject.split(piiResult.email).join(emailAsterisks);
+      }
+      
+      updates.email_subject = redactedSubject;
+    }
+
+    // Update database with redacted text
+    if (Object.keys(updates).length > 0) {
+      const { error: updateError } = await supabase
+        .from("submissions")
+        .update(updates)
+        .eq("id", submissionId);
+
+      if (updateError) {
+        console.error("redact-pii:update_failed", {
+          submissionId,
+          error: updateError,
+        });
+        return NextResponse.json(
+          { error: "database update failed" },
+          { status: 500 }
+        );
+      }
+
+      console.log("redact-pii:success", {
+        submissionId,
+        fieldsUpdated: Object.keys(updates),
+        name: piiResult.name,
+        email: piiResult.email,
+      });
+
+      return NextResponse.json({
+        ok: true,
+        redacted: true,
+        fieldsUpdated: Object.keys(updates),
+        confidence: piiResult.confidence,
+      });
+    }
+
+    console.log("redact-pii:no_updates", { submissionId });
+    return NextResponse.json({
+      ok: true,
+      redacted: false,
+      reason: "no_text_fields",
+    });
+  } catch (error) {
+    console.error("redact-pii:error", { error: String(error) });
+    return NextResponse.json(
+      { error: "internal server error" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/web/src/server/ai/redact-pii.ts
+++ b/web/src/server/ai/redact-pii.ts
@@ -1,0 +1,163 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface PIIDetectionResult {
+  name: string | null;
+  email: string | null;
+  confidence: number;
+  notes?: string;
+}
+
+/**
+ * Detect submitter's PII (name and email) from message content using AI.
+ * Uses text analysis to identify the person who forwarded/submitted the message.
+ */
+export async function detectPII(
+  rawText: string,
+  emailFrom?: string | null
+): Promise<PIIDetectionResult> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  
+  if (!apiKey) {
+    console.warn("detectPII:no_api_key");
+    return {
+      name: null,
+      email: null,
+      confidence: 0,
+      notes: "No API key available",
+    };
+  }
+
+  const model = "gpt-5-mini-2025-08-07";
+  
+  const system = `You are identifying PERSONAL INFORMATION (name and email) that should be redacted from a political fundraising message.
+
+Your task: Find any personalized recipient information (name and/or email address) that appears in the message content.
+
+Look for:
+- Personalized greetings: "Hi Ryan", "Dear Ryan Mioduski"
+- Personalized content: "NAME: Ryan Mioduski", "FOR: Ryan Mioduski", "Match offer for Ryan Mioduski"
+- Direct address in subject/body: "Your 600% match, Ryan"
+- Personal email addresses mentioned in the content (not org emails)
+- "From:" header lines with personal emails (gmail.com, outlook.com, yahoo.com, etc.) in forwarded messages
+
+Return the EXACT strings that should be redacted (the full name as it appears, the email as it appears).
+
+DO NOT extract:
+- Organization names
+- Political candidate names being discussed
+- PAC/committee names
+- Organization email addresses (like @dccc.org, @actblue.com, @democraticvictoryfund.org)
+- Generic greetings without names ("Hi there", "Dear Friend", "Dear Democrat")
+
+Return STRICT JSON only (no markdown):
+{
+  "name": string | null,
+  "email": string | null,
+  "confidence": <number between 0 and 1>,
+  "notes": "<brief explanation of what you found>"
+}
+
+Examples:
+- Input: "NAME: Ryan Mioduski\n4X-MATCH YOUR $6" → {"name": "Ryan Mioduski", "email": null, "confidence": 0.95}
+- Input: "Hi Ryan,\nYour match is unlocked!" → {"name": "Ryan", "email": null, "confidence": 0.85}
+- Input: "From: John Smith <john@gmail.com>" → {"name": "John Smith", "email": "john@gmail.com", "confidence": 0.9}
+- Input: "Paid for by Democratic Victory Fund" → {"name": null, "email": null, "confidence": 0.9, "notes": "No personal info"}
+
+Be conservative with confidence. Only return high confidence (≥0.7) when you find clear personalized content or personal email addresses.`;
+
+  type Message = { role: "system" | "user"; content: string };
+  
+  // Build message text
+  let messageText = "";
+  if (emailFrom) {
+    messageText += `From: ${emailFrom}\n\n`;
+  }
+  messageText += String(rawText || "").trim() || "(none)";
+  
+  const messages: Message[] = [
+    { role: "system", content: system },
+    { role: "user", content: messageText },
+  ];
+
+  try {
+    console.log("detectPII:calling_openai", { 
+      model, 
+      textLength: messageText.length,
+      hasEmailFrom: !!emailFrom,
+    });
+    
+    const startTime = Date.now();
+    const resp = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: { 
+        "Content-Type": "application/json", 
+        Authorization: `Bearer ${apiKey}` 
+      },
+      body: JSON.stringify({ 
+        model, 
+        messages,
+        reasoning_effort: "low",
+        verbosity: "low",
+      }),
+    });
+    
+    const elapsed = Date.now() - startTime;
+    
+    if (!resp.ok) {
+      const errorBody = await resp.json().catch(() => null);
+      console.error("detectPII:openai_failed", { 
+        status: resp.status, 
+        elapsed,
+        error: errorBody,
+      });
+      
+      return {
+        name: null,
+        email: null,
+        confidence: 0,
+        notes: `OpenAI API failed with status ${resp.status}`,
+      };
+    }
+    
+    const json = await resp.json();
+    const content = (json as any)?.choices?.[0]?.message?.content?.trim() || "{}";
+    
+    try {
+      const parsed = JSON.parse(content);
+      
+      console.log("detectPII:success", {
+        elapsed,
+        hasName: !!parsed.name,
+        hasEmail: !!parsed.email,
+        confidence: parsed.confidence,
+      });
+      
+      return {
+        name: typeof parsed.name === "string" && parsed.name.trim() ? parsed.name.trim() : null,
+        email: typeof parsed.email === "string" && parsed.email.trim() ? parsed.email.trim() : null,
+        confidence: typeof parsed.confidence === "number" ? parsed.confidence : 0,
+        notes: typeof parsed.notes === "string" ? parsed.notes : undefined,
+      };
+    } catch (parseError) {
+      console.warn("detectPII:parse_failed", { content, error: String(parseError) });
+      
+      return {
+        name: null,
+        email: null,
+        confidence: 0,
+        notes: "Failed to parse AI response",
+      };
+    }
+  } catch (error) {
+    const errorMsg = String(error);
+    console.warn("detectPII:error", { error: errorMsg });
+    
+    return {
+      name: null,
+      email: null,
+      confidence: 0,
+      notes: errorMsg.includes("abort") ? "Request timeout" : "Network error",
+    };
+  }
+}
+

--- a/web/src/server/ingest/text-cleaner.ts
+++ b/web/src/server/ingest/text-cleaner.ts
@@ -68,6 +68,49 @@ export function cleanTextForAI(text: string): string {
 }
 
 /**
+ * Attempt to repair common UTF-8 mojibake where UTF-8 bytes were decoded as Latin-1/Windows-1252.
+ * Example: "â" -> right single quote (’), "â" -> em dash (—), etc.
+ * Heuristic: only run re-decode when typical mojibake markers are present to avoid double-decoding.
+ */
+export function repairMojibake(input: string): string {
+  try {
+    if (!input) return input;
+    // Quick heuristic to detect mojibake patterns
+    const looksMojibake = /(?:Ã.|Â.|â(?:||||||)?|â¢|â|â¦|â|â)/.test(input);
+    if (!looksMojibake) return input;
+    // Interpret current code points as Latin-1 bytes and decode as UTF-8
+    const bytes = new Uint8Array(input.length);
+    for (let i = 0; i < input.length; i++) {
+      bytes[i] = input.charCodeAt(i) & 0xff;
+    }
+    const decoded = new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+    return decoded;
+  } catch {
+    return input;
+  }
+}
+
+/**
+ * Normalize common punctuation/specials to reduce duplicates and noisy variations.
+ * Keeps semantics but makes text more consistent for heuristics and dedupe.
+ */
+export function normalizePunctuation(input: string): string {
+  if (!input) return input;
+  return input
+    // Smart quotes → ASCII
+    .replace(/[\u2018\u2019\u201B\u2032]/g, "'")
+    .replace(/[\u201C\u201D\u201F\u2033]/g, '"')
+    // Dashes and ellipsis
+    .replace(/[\u2014\u2015]/g, "-") // em dash, horizontal bar
+    .replace(/[\u2013]/g, "-") // en dash
+    .replace(/[\u2026]/g, "...") // ellipsis
+    // Non-breaking and narrow spaces → regular space
+    .replace(/[\u00A0\u202F\u2007]/g, " ")
+    // Zero-width joiners are removed later by cleanTextForAI, but strip here if present
+    .replace(/[\u200B-\u200D\uFEFF]/g, "");
+}
+
+/**
  * Extract ActBlue URLs from text (even from redirects/tracking links)
  * Returns all ActBlue URLs found, prioritizing the one with most query params
  */


### PR DESCRIPTION
- Add detectPII() AI function to identify personalized content (names, emails)
- Add /api/redact-pii endpoint to redact and update database fields
- Integrate redaction into email and SMS ingestion pipelines (parallel, non-blocking)
- Redact exact matches in raw_text, email_body, and email_subject fields
- Use confidence threshold (≥0.5) to avoid false positives
- Preserve original text for AI classification, redact for display
- Tested with personalized content like 'NAME: Ryan Mioduski' and 'Hi Ryan'