### PR TITLE
refactor: move honeytrap email to server-side environment variable

### DIFF
--- a/SYSTEM_ARCHITECTURE.md
+++ b/SYSTEM_ARCHITECTURE.md
@@ -91,7 +91,7 @@ created_at timestamptz
    - Stores envelope sender as `envelopeSender` (forwarder's email)
    - Attempts to detect original sender from forwarded message body
    - Strips forwarded headers from text
-   - Redacts honeytrap email (democratdonor@gmail.com)
+   - Redacts honeytrap emails (from HONEYTRAP_EMAILS env var)
    - Cleans text via cleanTextForAI()
    - Sanitizes HTML via sanitizeEmailHtml()
    - Generates secure token: randomBytes(32).toString('base64url')
@@ -503,6 +503,9 @@ REPORT_EMAIL_FROM=reports@abjail.org
 # Site
 NEXT_PUBLIC_SITE_URL=https://abjail.org
 
+# Honeytrap emails (server-side only, comma-separated for multiple emails)
+HONEYTRAP_EMAILS=email1@example.com,email2@example.com
+
 # Deduplication
 DEDUP_SIMHASH_DISTANCE=4  # max hamming distance for duplicate detection
 ```
@@ -533,9 +536,11 @@ queued → ocr → classified → done
 - Marked as used BEFORE calling report-violation to prevent race conditions
 
 ### Honeytrap Email Protection
-- democratdonor@gmail.com is redacted throughout system
+- Honeytrap emails (configured via HONEYTRAP_EMAILS env var) are redacted server-side during ingestion
+- Supports multiple comma-separated emails for misdirection
 - Non-ActBlue links removed from email HTML
 - Prevents exposing honeytrap to third parties
+- No client-side redaction needed (data already clean from server)
 
 ### PII Redaction (Personalization Removal)
 - Runs after ingest as an isolated step for email/SMS/text

--- a/web/env.example
+++ b/web/env.example
@@ -25,3 +25,7 @@ REPORT_EMAIL_FROM=democratdonor+reports@gmail.com
 
 # GitHub integration (for bug report form)
 GITHUB_TOKEN=
+
+# Honeytrap emails (comma-separated, server-side only, DO NOT use NEXT_PUBLIC_)
+# Example: HONEYTRAP_EMAILS=email1@example.com,email2@example.com
+HONEYTRAP_EMAILS=

--- a/web/src/app/cases/[id]/client.tsx
+++ b/web/src/app/cases/[id]/client.tsx
@@ -1249,57 +1249,8 @@ type EvidenceTabsProps = {
 };
 
 export function EvidenceTabs({ caseId, messageType, rawText, emailBody, screenshotUrl, screenshotMime = null, landingImageUrl, landingLink, landingStatus }: EvidenceTabsProps) {
-  const HONEYTRAP_EMAIL = "democratdonor@gmail.com";
-  
-  const redactEmailsInText = (text: string): string => {
-    // First, always redact honeytrap email
-    const result = text.replace(new RegExp(HONEYTRAP_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'), '*******@*******.com');
-    
-    // Extract From: email to preserve it
-    const fromMatch = result.match(/From:\s*[^<\n]*?<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?/i);
-    const fromEmail = fromMatch ? fromMatch[1].toLowerCase() : null;
-    
-    return result.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, (email) => {
-      if (fromEmail && email.toLowerCase() === fromEmail) {
-        return email; // Preserve From: email
-      }
-      // Skip if already redacted
-      if (email.includes('*******')) return email;
-      try {
-        const parts = email.split("@");
-        const domain = parts[1] || "";
-        const tld = domain.includes(".") ? domain.split(".").pop() || "com" : "com";
-        return `${"*".repeat(7)}@${"*".repeat(7)}.${tld}`;
-      } catch {
-        return "****@****.***";
-      }
-    });
-  };
-
-  const redactEmailsInHtml = (html: string): string => {
-    // First, always redact honeytrap email
-    const result = html.replace(new RegExp(HONEYTRAP_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'), '*******@*******.com');
-    
-    // Extract From: email to preserve it
-    const fromMatch = result.match(/From:\s*[^<\n]*?<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?/i);
-    const fromEmail = fromMatch ? fromMatch[1].toLowerCase() : null;
-    
-    return result.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, (email) => {
-      if (fromEmail && email.toLowerCase() === fromEmail) {
-        return email; // Preserve From: email
-      }
-      // Skip if already redacted
-      if (email.includes('*******')) return email;
-      try {
-        const parts = email.split("@");
-        const domain = parts[1] || "";
-        const tld = domain.includes(".") ? domain.split(".").pop() || "com" : "com";
-        return `${"*".repeat(7)}@${"*".repeat(7)}.${tld}`;
-      } catch {
-        return "****@****.***";
-      }
-    });
-  };
+  // Note: Email redaction is now handled server-side during ingestion.
+  // The data we receive here is already redacted, so no client-side redaction is needed.
 
   const [tab, setTab] = useState<"primary" | "landing">("primary");
   const [scanUrl, setScanUrl] = useState("");
@@ -1414,12 +1365,12 @@ export function EvidenceTabs({ caseId, messageType, rawText, emailBody, screensh
                   <div className="scale-[0.5] origin-top" style={{ width: "calc(100% / 0.5)" }}>
                     <div 
                       className="prose prose-sm max-w-none text-slate-900 text-xs prose-headings:text-sm"
-                      dangerouslySetInnerHTML={{ __html: redactEmailsInHtml(emailBody) }}
+                      dangerouslySetInnerHTML={{ __html: emailBody }}
                     />
                   </div>
                 </div>
               ) : rawText ? (
-                <pre className="whitespace-pre-wrap break-words text-sm text-slate-900 max-h-96 overflow-auto">{redactEmailsInText(normalizePunctuation(repairMojibake(rawText)))}</pre>
+                <pre className="whitespace-pre-wrap break-words text-sm text-slate-900 max-h-96 overflow-auto">{normalizePunctuation(repairMojibake(rawText))}</pre>
               ) : (
                 <div className="text-slate-600 text-sm">No primary evidence available.</div>
               )}

--- a/web/src/lib/env.ts
+++ b/web/src/lib/env.ts
@@ -23,6 +23,9 @@ const EnvSchema = z.object({
 
   GITHUB_TOKEN: z.string().optional(),
 
+  // Honeytrap emails (comma-separated for misdirection)
+  HONEYTRAP_EMAILS: z.string().optional(),
+
   // Dedupe tuning
   DEDUP_SIMHASH_DISTANCE: z.coerce.number().default(4),
 });
@@ -58,6 +61,8 @@ export const env: AppEnv = EnvSchema.parse({
   REPORT_EMAIL_FROM: process.env.REPORT_EMAIL_FROM || process.env.REPORT_FROM_EMAIL,
 
   GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+
+  HONEYTRAP_EMAILS: process.env.HONEYTRAP_EMAILS,
 
   DEDUP_SIMHASH_DISTANCE: process.env.DEDUP_SIMHASH_DISTANCE,
 });


### PR DESCRIPTION
- Add HONEYTRAP_EMAILS env var (server-side only, supports comma-separated list)
- Update inbound-email route to use env var with graceful fallback
- Update AI sender prompt to reference env var
- Remove client-side redaction (security fix - was exposing secret in browser bundle)
- Server-side redaction during ingestion ensures data is already clean
- Add warning logs if env var is missing
- Update documentation to reflect env-based configuration