### PR TITLE
Fix: await non-fundraising notice to ensure completion in serverless 

### DIFF
--- a/web/src/app/api/inbound-email/route.ts
+++ b/web/src/app/api/inbound-email/route.ts
@@ -236,16 +236,14 @@ export async function POST(req: NextRequest) {
       
       // Send notice email to forwarder for non-fundraising submissions
       if (result.id && isForwarded && envelopeSender) {
-        const base = process.env.NEXT_PUBLIC_SITE_URL || "";
-        const noticeUrl = `${base}/api/send-non-fundraising-notice`;
-        
         console.log("/api/inbound-email:triggering_non_fundraising_notice", {
           submissionId: result.id,
           forwarder: parseEmailAddress(envelopeSender) || envelopeSender
         });
         
+        const base = process.env.NEXT_PUBLIC_SITE_URL || "";
         // Await to ensure completion in serverless environment
-        await fetch(noticeUrl, {
+        await fetch(`${base}/api/send-non-fundraising-notice`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ submissionId: result.id }),


### PR DESCRIPTION
The fire-and-forget fetch was terminating before completion in serverless
environments because the response was returned immediately after.
Await the fetch to ensure the notice email is sent.