### PR TITLE
Add multi-select sender search with autocomplete

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useRef, useState, Suspense } from "react";
-import { useSearchParams } from "next/navigation";
+import { useSearchParams, useRouter } from "next/navigation";
 import { assertSupabaseBrowser } from "@/lib/supabase";
 import { cachedJsonFetch } from "@/lib/client-cache";
 import Footer from "@/components/Footer";
@@ -822,6 +822,7 @@ function RecentCases() {
 function WorstOffenders() {
   const { stats, loading } = useHomepageStats();
   const offenders = stats.worst_offenders || [];
+  const router = useRouter();
 
   return (
     <section className="bg-white rounded-2xl border border-slate-200 shadow-sm p-4 md:p-6">
@@ -849,15 +850,22 @@ function WorstOffenders() {
               ))
             )}
             {!loading && offenders.slice(0, 5).map((o) => (
-              <tr key={o.sender_name} className="border-t hover:bg-slate-50">
+              <tr 
+                key={o.sender_name} 
+                className="border-t hover:bg-slate-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-slate-300"
+                role="button"
+                tabIndex={0}
+                aria-label={`View cases for ${o.sender_name}`}
+                onClick={() => router.push(`/cases?senders=${encodeURIComponent(o.sender_name)}`)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    router.push(`/cases?senders=${encodeURIComponent(o.sender_name)}`);
+                  }
+                }}
+              >
                 <td className="py-2 pr-4 text-slate-900">
-                  <Link
-                    href={`/cases?q=${encodeURIComponent(o.sender_name)}`}
-                    className="text-slate-900 hover:bg-slate-50 rounded px-1"
-                    aria-label={`View cases for ${o.sender_name}`}
-                  >
-                    {o.sender_name}
-                  </Link>
+                  {o.sender_name}
                 </td>
                 <td className="py-2 pr-4 tabular-nums text-slate-900">{o.violation_count}</td>
                 <td className="py-2 pr-4 text-slate-800">{formatWhen(o.latest_violation_at)}</td>

--- a/web/src/app/stats/page.tsx
+++ b/web/src/app/stats/page.tsx
@@ -865,11 +865,11 @@ function TopSendersTable({
                     role="button"
                     tabIndex={0}
                     aria-label={`View cases for ${s.sender}`}
-                    onClick={() => router.push(`/cases?q=${encodeURIComponent(s.sender)}`)}
+                    onClick={() => router.push(`/cases?senders=${encodeURIComponent(s.sender)}`)}
                     onKeyDown={(e) => {
                       if (e.key === "Enter" || e.key === " ") {
                         e.preventDefault();
-                        router.push(`/cases?q=${encodeURIComponent(s.sender)}`);
+                        router.push(`/cases?senders=${encodeURIComponent(s.sender)}`);
                       }
                     }}
                   >

--- a/web/src/components/sender-search-combobox.tsx
+++ b/web/src/components/sender-search-combobox.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { Search, X, Loader2, UserSearch } from "lucide-react";
+import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
+
+type SenderSearchComboboxProps = {
+  selectedSenders: string[];
+  pageSize: number;
+  codes: string[];
+};
+
+export function SenderSearchCombobox({ selectedSenders, pageSize, codes }: SenderSearchComboboxProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [senders, setSenders] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set(selectedSenders));
+  const debounceTimer = useRef<NodeJS.Timeout | null>(null);
+
+  // Fetch matching senders
+  const fetchSenders = useCallback(async (query: string) => {
+    if (!query.trim()) {
+      setSenders([]);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/cases?q=${encodeURIComponent(query)}&limit=20&include=`);
+      if (res.ok) {
+        const data = await res.json();
+        const items = data.items || [];
+        // Extract unique sender names
+        const uniqueSenders = new Set<string>();
+        items.forEach((item: { senderName?: string | null; senderId?: string | null }) => {
+          const name = item.senderName || item.senderId;
+          if (name && typeof name === 'string') {
+            uniqueSenders.add(name);
+          }
+        });
+        setSenders(Array.from(uniqueSenders));
+      }
+    } catch (error) {
+      console.error("Failed to fetch senders:", error);
+      setSenders([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Debounced search
+  useEffect(() => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+    }
+
+    debounceTimer.current = setTimeout(() => {
+      fetchSenders(searchQuery);
+    }, 300);
+
+    return () => {
+      if (debounceTimer.current) {
+        clearTimeout(debounceTimer.current);
+      }
+    };
+  }, [searchQuery, fetchSenders]);
+
+  const toggleSender = (sender: string) => {
+    const newSelected = new Set(selected);
+    if (newSelected.has(sender)) {
+      newSelected.delete(sender);
+    } else {
+      newSelected.add(sender);
+    }
+    setSelected(newSelected);
+  };
+
+  const removeSender = (sender: string) => {
+    const newSelected = new Set(selected);
+    newSelected.delete(sender);
+    setSelected(newSelected);
+    applySelection(newSelected);
+  };
+
+  const clearAll = () => {
+    setSelected(new Set());
+    applySelection(new Set());
+  };
+
+  const applySelection = (selection: Set<string> = selected) => {
+    const params = new URLSearchParams();
+    params.set("page", "1");
+    params.set("limit", String(pageSize));
+    
+    // Add codes filter if present
+    codes.forEach((code) => {
+      params.append("codes", code);
+    });
+
+    // Add selected senders
+    if (selection.size > 0) {
+      params.set("senders", Array.from(selection).join(","));
+    }
+
+    router.push(`/cases?${params.toString()}`);
+    setOpen(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.defaultPrevented) {
+      e.preventDefault();
+      applySelection();
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2 w-full md:w-auto">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="w-full md:w-[300px] justify-between text-left font-normal bg-white hover:bg-slate-50 border-slate-300"
+          >
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <Search className="h-4 w-4 shrink-0 text-slate-400" />
+              <span className="truncate text-slate-900">
+                {selected.size > 0 
+                  ? `${selected.size} sender${selected.size === 1 ? '' : 's'} selected`
+                  : "Search senders..."}
+              </span>
+            </div>
+            {selected.size > 0 && (
+              <Badge variant="secondary" className="ml-2 rounded-full bg-slate-900 text-white">
+                {selected.size}
+              </Badge>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[300px] md:w-[400px] p-0 bg-white border border-slate-200 shadow-lg" align="start">
+          <Command shouldFilter={false} onKeyDown={handleKeyDown} className="bg-white">
+            <div className="flex items-center gap-2 border-b border-slate-200 px-3 py-2 bg-white">
+              <Search className="h-4 w-4 shrink-0 text-slate-600" />
+              <input
+                type="text"
+                placeholder="Type to search senders..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="flex-1 h-8 bg-transparent text-sm outline-none placeholder:text-slate-500 text-slate-900"
+              />
+            </div>
+            <CommandList className="bg-white">
+              {loading ? (
+                <div className="py-6 text-center text-sm bg-white">
+                  <Loader2 className="h-4 w-4 animate-spin mx-auto mb-2 text-slate-600" />
+                  <span className="text-slate-600">Searching...</span>
+                </div>
+              ) : searchQuery.trim() === "" ? (
+                <div className="py-6 text-center text-sm text-slate-600 bg-white">
+                  Type to search for senders
+                </div>
+              ) : senders.length === 0 ? (
+                <CommandEmpty className="bg-white">
+                  <Empty className="py-4 bg-white">
+                    <EmptyHeader>
+                      <EmptyMedia variant="icon">
+                        <UserSearch className="h-8 w-8 text-slate-400" />
+                      </EmptyMedia>
+                      <EmptyTitle className="text-base text-slate-900">No senders found</EmptyTitle>
+                      <EmptyDescription className="text-xs text-slate-600">
+                        Try a different search term
+                      </EmptyDescription>
+                    </EmptyHeader>
+                  </Empty>
+                </CommandEmpty>
+              ) : (
+                <CommandGroup className="bg-white">
+                  {senders.map((sender) => (
+                    <CommandItem
+                      key={sender}
+                      value={sender}
+                      onSelect={() => toggleSender(sender)}
+                      className="cursor-pointer hover:bg-slate-100 aria-selected:bg-slate-100"
+                    >
+                      <div className="flex items-center gap-2 w-full">
+                        <input
+                          type="checkbox"
+                          checked={selected.has(sender)}
+                          onChange={() => {}}
+                          className="accent-slate-900 cursor-pointer"
+                        />
+                        <span className="flex-1 truncate text-slate-900">{sender}</span>
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
+            </CommandList>
+            {(selected.size > 0 || senders.length > 0) && (
+              <div className="border-t border-slate-200 p-2 flex items-center justify-between gap-2 bg-white">
+                {selected.size > 0 && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={clearAll}
+                    className="text-xs h-7 text-slate-700 hover:text-slate-900 hover:bg-slate-100"
+                  >
+                    Clear all
+                  </Button>
+                )}
+                <Button
+                  size="sm"
+                  onClick={() => applySelection()}
+                  className="ml-auto text-xs h-7 bg-slate-900 text-white hover:bg-slate-800"
+                >
+                  Apply {selected.size > 0 && `(${selected.size})`}
+                </Button>
+              </div>
+            )}
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      {/* Display selected senders as badges */}
+      {selected.size > 0 && (
+        <div className="flex items-center gap-1.5 flex-wrap">
+          {Array.from(selected).slice(0, 2).map((sender) => (
+            <Badge
+              key={sender}
+              variant="secondary"
+              className="max-w-[150px] pl-2 pr-1 py-1 gap-1 bg-slate-100 text-slate-900 border border-slate-300"
+            >
+              <span className="truncate text-xs">{sender}</span>
+              <button
+                onClick={() => removeSender(sender)}
+                className="ml-1 ring-offset-background rounded-full outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 hover:bg-slate-200"
+              >
+                <X className="h-3 w-3" />
+                <span className="sr-only">Remove {sender}</span>
+              </button>
+            </Badge>
+          ))}
+          {selected.size > 2 && (
+            <Badge variant="secondary" className="text-xs bg-slate-100 text-slate-900 border border-slate-300">
+              +{selected.size - 2} more
+            </Badge>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/web/src/components/ui/empty.tsx
+++ b/web/src/components/ui/empty.tsx
@@ -1,0 +1,104 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn(
+        "flex max-w-sm flex-col items-center gap-2 text-center",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const emptyMediaVariants = cva(
+  "flex shrink-0 items-center justify-center mb-2 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("text-lg font-medium tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+}


### PR DESCRIPTION
- Replace basic text search with shadcn combobox component
- Add autocomplete with debounced API search (300ms)
- Support multi-select with checkboxes for sender name variations
- Display selected senders as removable badge chips
- Add Empty component for no results state
- Update API to support multi-sender filtering with special characters
- Make homepage and stats page sender links use new filter badges
- Make table rows fully clickable for better UX