### PR TITLE
Fix: Remove onClick handler causing Server Component to Client Compon…

### DIFF
--- a/web/src/app/cases/page.tsx
+++ b/web/src/app/cases/page.tsx
@@ -278,7 +278,6 @@ export default async function CasesPage({ searchParams }: { searchParams?: Promi
                                           target="_blank"
                                           rel="noopener noreferrer"
                                           className="text-xs text-blue-600 hover:underline inline-flex items-center gap-1"
-                                          onClick={(e) => e.stopPropagation()}
                                         >
                                           View full policy
                                           <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
…ent prop error

- Removed onClick={(e) => e.stopPropagation()} from anchor tag in HoverCardContent
- Event handlers cannot be passed from Server Components to Client Components
- The stopPropagation was unnecessary since HoverCardContent renders in a Portal