### PR TITLE
fix(breadcrumb): prevent purple visited link and restore underline\n\…

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -28,6 +28,15 @@ body {
 /* Removed page-specific body classes to avoid FOUC */
 
 /* Breadcrumb links - prevent visited link color */
+.breadcrumb-link {
+  color: rgb(30, 41, 59) !important; /* text-slate-800 */
+  text-decoration: none !important;
+  font-weight: 500; /* match font-medium */
+}
+.breadcrumb-link:hover {
+  text-decoration: underline !important;
+  text-underline-offset: 2px !important;
+}
 .breadcrumb-link:visited {
-  color: rgb(30, 41, 59) !important;
+  color: rgb(30, 41, 59) !important; /* keep same as default to avoid purple */
 }

--- a/web/src/components/breadcrumb.tsx
+++ b/web/src/components/breadcrumb.tsx
@@ -26,7 +26,7 @@ export function Breadcrumb({ items, className }: BreadcrumbProps) {
               {item.href && !isLast ? (
                 <Link
                   href={item.href}
-                  className="breadcrumb-link text-base font-medium text-slate-800 transition-all hover:text-slate-950 hover:underline hover:underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 focus-visible:ring-offset-2 rounded-sm px-1 -mx-1"
+                  className="breadcrumb-link text-base font-medium text-slate-800 visited:text-slate-800 transition-all hover:text-slate-950 hover:underline hover:underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 focus-visible:ring-offset-2 rounded-sm px-1 -mx-1"
                 >
                   {item.label}
                 </Link>


### PR DESCRIPTION
…n- Enforce consistent breadcrumb link styles via globals.css (.breadcrumb-link)\n- Keep visited color same as default; ensure hover underline\n- Add visited:text-slate-800 to Breadcrumb component link to reinforce style on case page